### PR TITLE
Avoid need for package-lock.json in source repo

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,8 +58,9 @@ runs:
       working-directory: ${{ github.workspace }}/link-check
     - uses: actions/setup-node@v2
       with:
-        node-version: '16'
+        node-version: 'lts/*'
         cache: 'npm'
+        cache-dependency-path: link-check/package-lock.json
     - run: |
         echo "::group::npm install output"; \
         if test -e package.json -o -e package-lock.json; then npm install; fi; \


### PR DESCRIPTION
Attempt to remove require package.json and package-lock.json in the repo from which are called. They are still needed in this action's repo because the setup-node action requires it.

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>